### PR TITLE
Updated Velocity version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,8 +24,8 @@
     "tests"
   ],
   "dependencies": {
-    "angular-animate": "~1.2.15",
-    "angular": "~1.2.15",
-    "velocity": "~0.11.6"
+    "angular-animate": "~1.4.3",
+    "angular": "~1.4.3",
+    "velocity": "~1.2.2"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -24,8 +24,8 @@
     "tests"
   ],
   "dependencies": {
-    "angular-animate": "~1.4.3",
-    "angular": "~1.4.3",
+    "angular-animate": ">=1.2.15",
+    "angular": ">=1.2.15",
     "velocity": "~1.2.2"
   }
 }


### PR DESCRIPTION
This solves an error when loading Velocity:

`Velocity UI Pack: Velocity must be loaded first. Aborting.`

I've also updated the AngularJS dependencies, if it's not ok for you I can leave the Velocity change only.
